### PR TITLE
Fix issue with empty username and password

### DIFF
--- a/Github-Client/alexander/github/BasicAuth.swift
+++ b/Github-Client/alexander/github/BasicAuth.swift
@@ -10,14 +10,17 @@ import UIKit
 
 class BasicAuth: NSObject {
     static func sessionConfiguration() -> NSURLSessionConfiguration {
-        let username = "username"
-        let password = "password or token"
+        let username = ""
+        let password = ""
         let loginString = NSString(format: "%@:%@", username, password)
         let loginData: NSData = loginString.dataUsingEncoding(NSUTF8StringEncoding)!
         let base64LoginString = loginData.base64EncodedStringWithOptions(NSDataBase64EncodingOptions(rawValue: 0))
         let authString = "Basic \(base64LoginString)"
         let config = NSURLSessionConfiguration.defaultSessionConfiguration()
-        config.HTTPAdditionalHeaders = ["Authorization" : authString]
+        if !username.isEmpty && !password.isEmpty {
+            config.HTTPAdditionalHeaders = ["Authorization" : authString]
+        }
+        
         return config
     }
 }


### PR DESCRIPTION
Don't send authorization in html header if username or password empty
